### PR TITLE
Removed net/http/cookiejar requirement from package publicsuffix

### DIFF
--- a/publicsuffix/list.go
+++ b/publicsuffix/list.go
@@ -42,31 +42,15 @@
 // Instead, the calculation is data driven. This package provides a
 // pre-compiled snapshot of Mozilla's PSL (Public Suffix List) data at
 // https://publicsuffix.org/
-package publicsuffix // import "golang.org/x/net/publicsuffix"
+package publicsuffix
 
 // TODO: specify case sensitivity and leading/trailing dot behavior for
 // func PublicSuffix and func EffectiveTLDPlusOne.
 
 import (
 	"fmt"
-	"net/http/cookiejar"
 	"strings"
 )
-
-// List implements the cookiejar.PublicSuffixList interface by calling the
-// PublicSuffix function.
-var List cookiejar.PublicSuffixList = list{}
-
-type list struct{}
-
-func (list) PublicSuffix(domain string) string {
-	ps, _ := PublicSuffix(domain)
-	return ps
-}
-
-func (list) String() string {
-	return version
-}
 
 // PublicSuffix returns the public suffix of the domain using a copy of the
 // publicsuffix.org database compiled into the library.

--- a/publicsuffix/list_test.go
+++ b/publicsuffix/list_test.go
@@ -233,14 +233,14 @@ var publicSuffixTestCases = []struct {
 func BenchmarkPublicSuffix(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		for _, tc := range publicSuffixTestCases {
-			List.PublicSuffix(tc.domain)
+			PublicSuffix(tc.domain)
 		}
 	}
 }
 
 func TestPublicSuffix(t *testing.T) {
 	for _, tc := range publicSuffixTestCases {
-		got := List.PublicSuffix(tc.domain)
+		got, _ := PublicSuffix(tc.domain)
 		if got != tc.want {
 			t.Errorf("%q: got %q, want %q", tc.domain, got, tc.want)
 		}


### PR DESCRIPTION
This reduces the number of packages we need to import when using the publicsuffix package. 

Needed for https://gitlab.com/1password/xplatform-security/issues/3